### PR TITLE
fix(zsh): ~/.local/bin を mise のツールパスより前に保つ

### DIFF
--- a/home/dot_config/zsh/init/mise.zsh
+++ b/home/dot_config/zsh/init/mise.zsh
@@ -5,3 +5,14 @@ if command -v mise >/dev/null 2>&1; then
 elif [ -x "$HOME/.local/bin/mise" ]; then
     eval "$("$HOME/.local/bin/mise" activate zsh)"
 fi
+
+# `mise activate` prepends managed tool bin dirs to PATH (including its own
+# python), which shadows the python/python3 wrappers in ~/.local/bin. Re-prepend
+# ~/.local/bin so the wrappers win. Do it both immediately (covers non-interactive
+# login shells that never reach .zshrc) and via a precmd hook registered *after*
+# mise's, since mise re-prepends its dirs on every prompt.
+if [ -d "$HOME/.local/bin" ]; then
+    _mise_local_bin_first() { path=("$HOME/.local/bin" ${path:#$HOME/.local/bin}) }
+    _mise_local_bin_first
+    autoload -Uz add-zsh-hook && add-zsh-hook precmd _mise_local_bin_first
+fi

--- a/home/dot_zshrc
+++ b/home/dot_zshrc
@@ -30,6 +30,3 @@ eval "$(starship init zsh)"
 eval "$(zoxide init zsh)"
 eval "$(git wt --init zsh)"
 
-# Ensure ~/.local/bin overrides mise shims (for python/python3 wrappers etc.)
-path=("$HOME/.local/bin" ${path:#$HOME/.local/bin})
-


### PR DESCRIPTION
## 問題
`PYTHON_WITH=pyyaml python3 -c 'import yaml'` 等が `ModuleNotFoundError: No module named 'yaml'` になっていた。

## 原因
`~/.local/bin/python`・`python3`（`uv run` ルーティングを行うラッパー）が mise の管理 python に隠されていた。

1. `mise activate` がツールの bin（managed python 含む）を PATH 先頭に前置し、さらに `precmd` フック（`_mise_hook_precmd`）が**毎プロンプトで再前置**するため、`~/.local/bin` が常に後ろに回る。
2. 従来の対策（`~/.local/bin` の前置）は **`.zshrc`（対話シェルのみ）にしか無く**、非対話ログインシェル（`zsh -lc ...`）では効かなかった。

結果、`python3` が mise の素の python に解決され、ラッパーを通らないため `PYTHON_WITH` / `uv run` が無視されていた。

## 修正
共有 init の `mise.zsh` に集約:
- `mise activate` 直後に `~/.local/bin` を**即時前置**（非対話ログインシェルを含め全シェルをカバー）
- mise の後に走る `precmd` フックを登録し、毎プロンプトでの前置を維持（mise の再前置に勝つ）
- 冗長になった `.zshrc` 側の前置を削除

## 動作確認
- `command -v python3` → `~/.local/bin/python3`（非対話ログインシェルで確認）
- `PYTHON_WITH=pyyaml python3 -c 'import yaml'` / heredoc 形式ともに `yaml 6.0.3` を import 成功
- precmd を複数回発火させてもラッパーが先頭を維持
- `chezmoi apply` 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)